### PR TITLE
Bug: react table updates with old value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## <next>
 * Fix modal table updating on input
+* Update README.md
 
 ## 1.0.0
 * Improved localization configurability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
-
+* Fix modal table updating on input
 
 ## 1.0.0
 * Improved localization configurability

--- a/README.md
+++ b/README.md
@@ -48,10 +48,16 @@ export default class ReactView extends React.Component {
   render() {
     return (
       <Dropdown
-        i18n={{
-          getMessage: id => id,
+        localizationTexts={{
+          searchBy: 'Search by',
+          by: 'By',
+          close: 'Close',
+          select: 'Select',
+          loading: 'Loading...',
+          noItems: 'No items',
+          "field.fieldName1": 'my field',
+          "field.fieldName2": 'another field'
         }}
-        mapTranslationKey={key => `Common.Translations.${key}`}
         value={'a'}
         loadOptions={
           () => Promise.resolve({

--- a/src/SearchModal/SearchModal.js
+++ b/src/SearchModal/SearchModal.js
@@ -55,11 +55,11 @@ class SearchModal extends Component {
       [fieldName]: value,
     };
     this.setState({
-      page: 0,
-      searchFields: newSearchFields,
+      searchFields: newSearchFields
     });
-    this.handleFetchData({
+    this.fetchData({
       searchFields: newSearchFields,
+      page: 0,
     });
   };
 
@@ -144,7 +144,7 @@ class SearchModal extends Component {
           type="text"
           id={`search-field-${fieldName}`}
           value={value}
-          onChange={e => {
+          onInput={e => {
             this.setSearchValue(fieldName, e.target.value)
           }}
         />


### PR DESCRIPTION
When changing the value of a search field, the ReactTable updates with the previous value.

This PR includes the following changes:
* Fixed an error in updating modal component's state on input
* Updated example in README to match current props