### PR TITLE
Add localization for paging component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Add possibility to localize paging component
 
 ## 1.0.10
 * Provide more space for selected value text

--- a/README.md
+++ b/README.md
@@ -21,26 +21,33 @@ Also you need to configure sass loader, since all the styles are in sass format.
 * Add [SASS loader](https://github.com/webpack-contrib/sass-loader) to support importing of SASS styles.
 
 ### API
-| Prop name                        | Type     | Default                                            | Description                                    |
-| -------------------------------- | -------- | -------------------------------------------------- | ---------------------------------------------- |
-| value                            | any      |                                                    | The initially selected value                   |
-| onSelect                         | function | () => {}                                           | Selection callback function                    |
-| handleChange                     | function | Sets internal state and calls setState callback    | Handles internal state on selecting an item    |
-| loadOptions                      | function | () => Promise.resolve({ options: [] })             | Function for fetching options for the combobox |
-| disabled                         | boolean  | false                                              | Disables the component from user interaction   |
-| localizationTexts                | object   |                                                    | A dictionary with translated texts as values   |
-| localizationTexts.["searchBy"]   |          |                                                    | UI text prefix for the first search field      |
-| localizationTexts.["by"]         |          |                                                    | UI text prefix for other search fields         |
-| localizationTexts.["close"]      |          |                                                    | UI text for the Close-button                   |
-| localizationTexts.["select"]     |          |                                                    | UI text for the Select-button                  |
-| localizationTexts.["loading"]    |          |                                                    | UI text for the loading state                  |
-| localizationTexts.["noItems"]    |          |                                                    | UI text for an empty result set                |
-| localizationTexts.["field.XYZ"]  |          |                                                    | Label for the search field with name "XYZ"     |
-| localizationTexts.["column.XYZ"] |          |                                                    | Header for the column with name "XYZ"          |
-| modal                            | object   |                                                    | Modal dialog specific props                    |
-| modal.title                      | string   | ''                                                 | Localized title of the modal                   |
-| modal.fields                     | [string] | []                                                 | List of fields to show as columns              |
-| modal.loadOptions                | function | () => Promise.resolve({ data: [], totalCount: 0 }) | Function for fetching entries to the table     |
+| Prop name                              | Type     | Default                                            | Description                                    |
+| -------------------------------------- | -------- | -------------------------------------------------- | ---------------------------------------------- |
+| value                                  | any      |                                                    | The initially selected value                   |
+| onSelect                               | function | () => {}                                           | Selection callback function                    |
+| handleChange                           | function | Sets internal state and calls setState callback    | Handles internal state on selecting an item    |
+| loadOptions                            | function | () => Promise.resolve({ options: [] })             | Function for fetching options for the combobox |
+| disabled                               | boolean  | false                                              | Disables the component from user interaction   |
+| localizationTexts                      | object   |                                                    | A dictionary with translated texts as values   |
+| localizationTexts.["searchBy"]         | string   |                                                    | UI text prefix for the first search field      |
+| localizationTexts.["by"]               | string   |                                                    | UI text prefix for other search fields         |
+| localizationTexts.["close"]            | string   |                                                    | UI text for the Close-button                   |
+| localizationTexts.["select"]           | string   |                                                    | UI text for the Select-button                  |
+| localizationTexts.["field.XYZ"]        | string   |                                                    | Label for the search field with name "XYZ"     |
+| localizationTexts.["column.XYZ"]       | string   |                                                    | Header for the column with name "XYZ"          |
+| localizationTexts.["loading"]          | string   | 'Loading...'                                       | Loading placeholder text                       |
+| localizationTexts.["noData"]           | string   | 'No rows found'                                    | Empty result set text                          |
+| localizationTexts.["previous"]         | string   | 'Previous'                                         | Paging text                                    |
+| localizationTexts.["next"]             | string   | 'Next'                                             | Paging text                                    |
+| localizationTexts.["page"]             | string   | 'Page'                                             | Paging text                                    |
+| localizationTexts.["of"]               | string   | 'of'                                               | Paging text                                    |
+| localizationTexts.["rows"]             | string   | 'rows'                                             | Paging text                                    |
+| localizationTexts.["pageJump"]         | string   | 'jump to page'                                     | Paging text                                    |
+| localizationTexts.["rowsSelector"]     | string   | 'rows per page'                                    | Paging text                                    |
+| modal                                  | object   |                                                    | Modal dialog specific props                    |
+| modal.title                            | string   | ''                                                 | Localized title of the modal                   |
+| modal.fields                           | [string] | []                                                 | List of fields to show as columns              |
+| modal.loadOptions                      | function | () => Promise.resolve({ data: [], totalCount: 0 }) | Function for fetching entries to the table     |
 
 ### Code example
 ```jsx
@@ -56,12 +63,19 @@ export default class ReactView extends React.Component {
           by: 'By',
           close: 'Close',
           select: 'Select',
-          loading: 'Loading...',
-          noItems: 'No items',
           "field.fieldName1": 'my field',
           "field.fieldName2": 'another field'
           "column.fieldName1": 'My field',
-          "column.fieldName2": 'Another field'
+          "column.fieldName2": 'Another field',
+          "previous": "PREV",
+          "next": "NEXT",
+          "loading": "LOADING",
+          "noData": "NODATA",
+          "page": "PAGE",
+          "of": "OF",
+          "rows": "ROWS",
+          "pageJump": "JUMP",
+          "rowsSelector": "RPP",
         }}
         disabled={false}
         value={'a'}

--- a/src/SearchModal/SearchModal.js
+++ b/src/SearchModal/SearchModal.js
@@ -27,6 +27,18 @@ const DEFAULT_STATE_VALUES = {
   loading: true,
 };
 
+const DEFAULT_TEXTS = {
+  previous: 'Previous',
+  next: 'Next',
+  loading: 'Loading...',
+  noData: 'No rows found',
+  page: 'Page',
+  of: 'of',
+  rows: 'rows',
+  pageJump: 'jump to page',
+  rowsSelector: 'rows per page',
+};
+
 
 class SearchModal extends Component {
   constructor(props) {
@@ -174,6 +186,18 @@ class SearchModal extends Component {
     });
     const [firstField, ...otherFields] = fieldObjects;
 
+    const texts = {
+      previousText: localizationTexts.previous || DEFAULT_TEXTS.previous,
+      nextText: localizationTexts.next || DEFAULT_TEXTS.next,
+      loadingText: localizationTexts.loading || DEFAULT_TEXTS.loading,
+      noDataText: localizationTexts.noData || DEFAULT_TEXTS.noData,
+      pageText: localizationTexts.page || DEFAULT_TEXTS.page,
+      ofText: localizationTexts.of || DEFAULT_TEXTS.of,
+      rowsText: localizationTexts.rows || DEFAULT_TEXTS.rows,
+      pageJumpText: localizationTexts.pageJump || DEFAULT_TEXTS.pageJump,
+      rowsSelectorText: localizationTexts.rowsSelector || DEFAULT_TEXTS.rowsSelector,
+    };
+
     return (
       <Modal className="combobox-with-search__modal" show={this.props.showModal} onHide={this.handleClose}>
         <Modal.Header closeButton={true}>
@@ -205,11 +229,12 @@ class SearchModal extends Component {
           <div className="combobox-with-search__modal-search-results">
             <ReactTable
               {...REACT_TABLE_PROPS}
+              {...texts}
               data={searchResults}
               columns={columns}
               pageSize={pageSize}
               loadingText={localizationTexts.loading}
-              noDataText={loading ? '' : localizationTexts.noItems}
+              noDataText={loading ? '' : localizationTexts.noData}
               loading={loading}
               pages={pages}
               page={page}

--- a/src_docs/components/example.component.js
+++ b/src_docs/components/example.component.js
@@ -68,10 +68,17 @@ export default class ComponentView extends React.PureComponent {
               "field.description": "description",
               "column.code": "Code",
               "column.description": "Description",
-              "loading": "Loading...",
-              "noItems": "No items",
               "searchBy": "Search by",
-              "by": "by"
+              "by": "by",
+              "previous": "PREV",
+              "next": "NEXT",
+              "loading": "LOADING",
+              "noData": "NODATA",
+              "page": "PAGE",
+              "of": "OF",
+              "rows": "ROWS",
+              "pageJump": "JUMP",
+              "rowsSelector": "RPP",
             }}
             value={{ value: 'b', label: 'second char commonStr' }}
             loadOptions={comboLoadOptions}
@@ -97,7 +104,7 @@ export default class ComponentView extends React.PureComponent {
               "column.code": "Code",
               "column.description": "Description",
               "loading": "Loading...",
-              "noItems": "No items",
+              "noData": "No items",
               "searchBy": "Search by",
               "by": "by"
             }}
@@ -128,7 +135,7 @@ export default class ComponentView extends React.PureComponent {
               "column.code": "Code",
               "column.description": "Description",
               "loading": "Loading...",
-              "noItems": "No items",
+              "noData": "No items",
               "searchBy": "Search by",
               "by": "by"
             }}


### PR DESCRIPTION
Add possibility to localize paging component.

Adds the following properties to `localizationTexts` prop object:
- `previous`
- `next`
- `page`
- `of`
- `rows`
- `pageJump`
- `rowsSelector`

Renames the following properties in `localizationTexts` prop object:
- `noItems` -> `noData`