### PR TITLE
Feature/24-fix1: Fixed destroy -call on an uninitialized Tether component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Fixed destroy -call on an uninitialized Tether component
 
 ## 2.3.0
 * Modified dropdown component to apply tethering on dropdown menu

--- a/src/ComboboxWithSearch/TetherComponent/TetherComponent.js
+++ b/src/ComboboxWithSearch/TetherComponent/TetherComponent.js
@@ -61,7 +61,9 @@ export default class TetherComponent extends React.PureComponent {
 
   destroyTetheredContent() {
     ReactDOM.unmountComponentAtNode(this.tetherContainer);
-    this.tether.destroy();
+    if (this.tether) {
+      this.tether.destroy();
+    }
     document.body.removeChild(this.tetherContainer);
   }
 


### PR DESCRIPTION
Component misbehaves if the search modal is opened before the dropdown menu is opened. This was due to a `destroy` method being called on an uninitialized `Tether`-component.