### PR TITLE
Add child tether component height tracking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
+## 3.0.1
+* Updated drop down menu to flip based on left space.
+
 ## 3.0.0
 * Remove handleChange prop and let the consuming app to determine how values are
   set

--- a/lib/cjs/ComboboxWithSearch/FloatingMenu/FloatingMenu.scss
+++ b/lib/cjs/ComboboxWithSearch/FloatingMenu/FloatingMenu.scss
@@ -1,0 +1,3 @@
+.opuscapita_react-select__menu {
+  position: static;
+}

--- a/lib/es/ComboboxWithSearch/FloatingMenu/FloatingMenu.scss
+++ b/lib/es/ComboboxWithSearch/FloatingMenu/FloatingMenu.scss
@@ -1,0 +1,3 @@
+.opuscapita_react-select__menu {
+  position: static;
+}

--- a/src/ComboboxWithSearch/FloatingMenu/FloatingMenu.js
+++ b/src/ComboboxWithSearch/FloatingMenu/FloatingMenu.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { components } from 'react-select';
 
 import TetherComponent from '../TetherComponent';
+import './FloatingMenu.scss';
 
 const options = {
   attachment: 'top left',

--- a/src/ComboboxWithSearch/FloatingMenu/FloatingMenu.scss
+++ b/src/ComboboxWithSearch/FloatingMenu/FloatingMenu.scss
@@ -1,0 +1,3 @@
+.opuscapita_react-select__menu {
+  position: static;
+}

--- a/src/ComboboxWithSearch/TetherComponent/TetherComponent.js
+++ b/src/ComboboxWithSearch/TetherComponent/TetherComponent.js
@@ -31,6 +31,11 @@ export default class TetherComponent extends React.PureComponent {
     matchWidth: PropTypes.bool.isRequired,
   }
 
+  constructor(props) {
+    super(props);
+    this.tetherChild = React.createRef();
+  }
+
   componentDidMount() {
     this.tetherContainer = document.createElement('div');
     document.body.appendChild(this.tetherContainer);
@@ -39,6 +44,13 @@ export default class TetherComponent extends React.PureComponent {
 
   componentDidUpdate() {
     this.renderTetheredContent();
+    if (this.tetherChild.current) {
+      this.tetherChildNode = ReactDOM.findDOMNode(this.tetherChild.current);
+      let [margin] = window.getComputedStyle(this.tetherChildNode).margin.split(' ');
+      // expects that margin is in px
+      margin = margin.match(/\d+/);
+      this.marginOffset = margin * 2;
+    }
   }
 
   componentWillUnmount() {
@@ -52,6 +64,10 @@ export default class TetherComponent extends React.PureComponent {
         element: this.tetherContainer,
         target: this.props.target,
       });
+    }
+    if (this.tetherChildNode) {
+      const height = this.tetherChildNode.clientWidth ? this.tetherChildNode.clientHeight + this.marginOffset : 0;
+      this.tetherContainer.style.height = `${height}px`;
     }
     if (this.props.matchWidth) {
       this.tetherContainer.style.width = `${this.props.target.clientWidth}px`;
@@ -70,6 +86,7 @@ export default class TetherComponent extends React.PureComponent {
   renderTetheredContent() {
     ReactDOM.render(
       <TetheredChildrenComponent
+        ref={this.tetherChild}
         target={this.props.target}
         position={this.position}
       >


### PR DESCRIPTION
## Problem
Source task in IPA https://opuscapita.atlassian.net/browse/IPA-652

<details>
<summary> If select used at the bottom of the page menu items become hidden </summary>

IPA invoice

![image](https://user-images.githubusercontent.com/39185158/102625712-f34f8580-4156-11eb-8c0a-6bf9805db1e0.png)

from DEMO

![image](https://user-images.githubusercontent.com/39185158/102625930-3873b780-4157-11eb-927f-65f10f8ea915.png)

</details> 

Tether (http://tether.io/) component by itself can track that, but used menu has own `position: absolute` property and Tether container which holds menu items doesn't track its size.

## Changes

Added menu size change tracking for Tether container which displays menu items.

## Demo

<details> 
<summary> IPA invoice  </summary>

![duplicate](https://user-images.githubusercontent.com/39185158/102626439-d5ceeb80-4157-11eb-8944-16df8f3fd877.gif)\

</details>

<details> 
<summary> DEMO </summary>

![react-async-demo](https://user-images.githubusercontent.com/39185158/102626456-dbc4cc80-4157-11eb-920b-bcf73221cc1d.gif)


</details>